### PR TITLE
更新了中英文README.md文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 阿里通义 (Qwen) 接口转API [qwen-free-api](https://github.com/LLM-Red-Team/qwen-free-api)
 
-ZhipuAI (智谱清言) 接口转API [glm-free-api](https://github.com/LLM-Red-Team/glm-free-api)
+智谱AI (智谱清言) 接口转API [glm-free-api](https://github.com/LLM-Red-Team/glm-free-api)
 
 秘塔AI (Metaso) 接口转API [metaso-free-api](https://github.com/LLM-Red-Team/metaso-free-api)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@ Fully compatible with the ChatGPT interface.
 
 Also, the following six free APIs are available for your attention:
 
-Step to the Stars (StepChat) API to API [step-free-api](https://github.com/LLM-Red-Team/step-free-api)
+StepFun (StepChat) API to API [step-free-api](https://github.com/LLM-Red-Team/step-free-api)
 
 Ali Tongyi (Qwen) API to API [qwen-free-api](https://github.com/LLM-Red-Team/qwen-free-api)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -24,7 +24,7 @@ MetaAI (metaso) API to API [metaso-free-api](https://github.com/LLM-Red-Team/met
 
 Iflytek Spark (Spark) API to API [spark-free-api](https://github.com/LLM-Red-Team/spark-free-api)
 
-Listening Intelligence (Emohaa) API to API [emohaa-free-api](https://github.com/LLM-Red-Team/emohaa-free-api)
+Lingxin Intelligence (Emohaa) API to API [emohaa-free-api](https://github.com/LLM-Red-Team/emohaa-free-api)
 
 ## Table of Contents
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -18,7 +18,7 @@ Step to the Stars (StepChat) API to API [step-free-api](https://github.com/LLM-R
 
 Ali Tongyi (Qwen) API to API [qwen-free-api](https://github.com/LLM-Red-Team/qwen-free-api)
 
-ZhipuAI (Wisdom Map Clear Words) API to API [glm-free-api](https://github.com/LLM-Red-Team/glm-free-api)
+ZhipuAI (ChatGLM) API to API [glm-free-api](https://github.com/LLM-Red-Team/glm-free-api)
 
 MetaAI (metaso) API to API [metaso-free-api](https://github.com/LLM-Red-Team/metaso-free-api)
 


### PR DESCRIPTION
根据发布的大模型名字，把智谱模型英文名字`Wisdom Map Clear Words`更改为`ChatGLM`
中文README文件里的`ZhipuAI`也给修改为`智谱AI`

更添：把`Step to the Stars`更改为`StepFun`， 阶跃星辰的英文公司名: https://www.stepfun.com/
把`Listening Intelligence`更改为`Lingxin Intelligence`