### PR TITLE
更新了英文的README_EN.md

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -20,7 +20,7 @@ Ali Tongyi (Qwen) API to API [qwen-free-api](https://github.com/LLM-Red-Team/qwe
 
 ZhipuAI (ChatGLM) API to API [glm-free-api](https://github.com/LLM-Red-Team/glm-free-api)
 
-MetaAI (metaso) API to API [metaso-free-api](https://github.com/LLM-Red-Team/metaso-free-api)
+Meta Sota (metaso) API to API [metaso-free-api](https://github.com/LLM-Red-Team/metaso-free-api)
 
 Iflytek Spark (Spark) API to API [spark-free-api](https://github.com/LLM-Red-Team/spark-free-api)
 


### PR DESCRIPTION
修改`MetaAI`为秘塔外文名`Meta Sota`并区别与脸书的Meta AI